### PR TITLE
remove aerogear irc channel for travis hooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ jdk:
   - openjdk7
   - oraclejdk8
 
-notifications:
-  irc: "irc.freenode.org#aerogear"
-
 branches:
   only:
     - master


### PR DESCRIPTION
Glad you guys are enjoying the UPS, but removing the IRC hook for travis

If interested, we can talk on our dev list, about if some fixes might make sense in UPS upstream