### PR TITLE
CAPP-11677CAPP-11677 getTenantRelations should get latest user (UUID) if more then one exist for an application

### DIFF
--- a/model/nosql/src/main/java/org/jboss/aerogear/unifiedpush/cassandra/dao/model/UserKey.java
+++ b/model/nosql/src/main/java/org/jboss/aerogear/unifiedpush/cassandra/dao/model/UserKey.java
@@ -61,4 +61,12 @@ public class UserKey implements Serializable {
 		this.pushApplicationId = pushApplicationId;
 	}
 
+	@Override
+	public String toString() {
+        return getClass().getSimpleName()
+            + "[alias=" + getAlias()
+            + ", id=" + getId()
+            + ", pushApplicationId=" + getPushApplicationId()
+            + "]";
+	}
 }


### PR DESCRIPTION
Long time ago, when users was created in UPS with the same alias, a new user was created and the old one was not deleted, so we have old users (that created around Feb/2017) that have more then one records, for example:

cqlsh:unifiedpush_server> select * from users_by_alias where alias = 'phone_example';

 alias         | user_id                              | push_application_id
---------------+--------------------------------------+--------------------------------------
phone_example | dfd30d70-07e8-11e7-a9ec-ff5afc71b8a7 | d555bce8-37b3-44c5-bac6-dccd8e194220
phone_example | dac8b390-fbfd-11e6-a38d-9b3d1290a92c | d555bce8-37b3-44c5-bac6-dccd8e194220

in that case, when filling up the userClaim into the user json, it have more then one claim that matches the client id. so the user get response code 401.

This fix is handling the problem the same way it handled when this user is requesting documents, it takes the latest user UUID for that application. 