### PR TITLE
CAPP-11910 Add support for sending notifications based on users UUIDs

### DIFF
--- a/model/nosql/src/main/java/org/jboss/aerogear/unifiedpush/cassandra/dao/AliasDao.java
+++ b/model/nosql/src/main/java/org/jboss/aerogear/unifiedpush/cassandra/dao/AliasDao.java
@@ -1,6 +1,7 @@
 package org.jboss.aerogear.unifiedpush.cassandra.dao;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -42,6 +43,8 @@ public interface AliasDao {
 	Stream<Row> findUserIds(UUID pushApplicationId);
 
 	Alias findOne(UUID pushApplicationId, UUID userId);
+
+	Map<String, User.AliasType> findAll(UUID pushApplicationId, UUID userId);
 
 	Stream<UserKey> findAllUserTenantRelations();
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/AliasService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/AliasService.java
@@ -17,11 +17,13 @@
 package org.jboss.aerogear.unifiedpush.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 import org.jboss.aerogear.unifiedpush.api.Alias;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.cassandra.dao.model.User;
 import org.jboss.aerogear.unifiedpush.cassandra.dao.model.UserKey;
 import org.jboss.aerogear.unifiedpush.service.impl.AliasServiceImpl.Associated;
 import org.jboss.aerogear.unifiedpush.service.impl.UserTenantInfo;
@@ -63,6 +65,8 @@ public interface AliasService {
 	Alias find(String pushApplicationId, String alias);
 
 	Alias find(UUID pushApplicationId, UUID userId);
+
+	Map<String, User.AliasType> findAll(UUID pushApplicationId, UUID userId);
 
 	/**
 	 * Removes all entries matching provided alias

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/AliasService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/AliasService.java
@@ -62,6 +62,8 @@ public interface AliasService {
 
 	Associated associated(String fqdn, String alias);
 
+	List<Alias> findAll(UUID pushApplicationId);
+
 	Alias find(String pushApplicationId, String alias);
 
 	Alias find(UUID pushApplicationId, UUID userId);

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/AliasServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/AliasServiceImpl.java
@@ -138,6 +138,11 @@ public class AliasServiceImpl implements AliasService {
 	}
 
 	@Override
+	public List<Alias> findAll(UUID pushApplicationId) {
+		return aliasDao.findAll(pushApplicationId);
+	}
+
+	@Override
 	public Alias find(UUID pushApplicationId, UUID userId) {
 		return aliasDao.findOne(pushApplicationId, userId);
 	}

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/AliasServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/AliasServiceImpl.java
@@ -142,6 +142,11 @@ public class AliasServiceImpl implements AliasService {
 		return aliasDao.findOne(pushApplicationId, userId);
 	}
 
+	@Override
+	public Map<String, User.AliasType> findAll(UUID pushApplicationId, UUID userId) {
+		return aliasDao.findAll(pushApplicationId, userId);
+	}
+
 	/**
 	 * Test if user exists / registered to KC.
 	 *


### PR DESCRIPTION
The main idea is that we send notifications to all of the users aliases with the knowledge (hope ?) that only aliases associated with an active device token will actually trigger a push notification. To that end, we also use case **insensitive** accumulation of the aliases in order to overcome the case where several mail addresses are registered as aliases but they differ only in case due to an earlier feature/patch that may create such entries (due to other considerations).